### PR TITLE
Remove deprecated meta content-language element

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,6 @@
   <meta name="subject" content="Project Sand" />
   <meta charset="UTF-8">
   <meta name="google" content="notranslate">
-  <meta http-equiv="Content-Language" content="en">
   <link rel="icon" href="assets/favicon.ico" type="image/x-icon" />
   <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
 


### PR DESCRIPTION
Fixes the [validation](https://validator.w3.org/nu/?doc=https%3A%2F%2Fwww.projectsand.io%2F) error:

> Using the `meta` element to specify the document-wide default language is obsolete. Consider specifying the language on the root element instead.
> From line 13, column 3; to line 13, column 51
> ````
> slate">↩  <meta http-equiv="Content-Language" content="en">↩  <li
> ````

In HTML5 it is sufficient to have the lang attribute on the main `<html>` element. See <https://www.w3.org/International/questions/qa-http-and-lang.en#meta_summary>.